### PR TITLE
Add doc/tags to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
This is just so that when you generate the help tags with `:helptags`, the tags don´t make your index dirty.